### PR TITLE
Windows build & link fixes

### DIFF
--- a/cubeb-api/libcubeb-sys/build.rs
+++ b/cubeb-api/libcubeb-sys/build.rs
@@ -42,9 +42,12 @@ fn main() {
         .build();
 
     if windows {
-        // TBD
         println!("cargo:rustc-link-lib=static=cubeb");
-        println!("cargo:rustc-link-search=native={}/lib", dst.display());
+        println!("cargo:rustc-link-search=native={}", dst.display());
+        println!("cargo:rustc-link-lib=dylib=avrt");
+        println!("cargo:rustc-link-lib=dylib=ole32");
+        println!("cargo:rustc-link-lib=dylib=user32");
+        println!("cargo:rustc-link-lib=dylib=winmm");
     } else if darwin {
         println!("cargo:rustc-link-lib=static=cubeb");
         println!("cargo:rustc-link-lib=framework=AudioUnit");

--- a/cubeb-core/src/lib.rs
+++ b/cubeb-core/src/lib.rs
@@ -324,9 +324,9 @@ pub enum ErrorCode {
 /// output device (e.g. headphones).
 bitflags! {
     pub struct DeviceType: ffi::cubeb_device_type {
-        const DEVICE_TYPE_UNKNOWN = ffi::CUBEB_DEVICE_TYPE_UNKNOWN as u32;
-        const DEVICE_TYPE_INPUT = ffi::CUBEB_DEVICE_TYPE_INPUT as u32;
-        const DEVICE_TYPE_OUTPUT = ffi::CUBEB_DEVICE_TYPE_OUTPUT as u32;
+        const DEVICE_TYPE_UNKNOWN = ffi::CUBEB_DEVICE_TYPE_UNKNOWN as _;
+        const DEVICE_TYPE_INPUT = ffi::CUBEB_DEVICE_TYPE_INPUT as _;
+        const DEVICE_TYPE_OUTPUT = ffi::CUBEB_DEVICE_TYPE_OUTPUT as _;
     }
 }
 


### PR DESCRIPTION
These minor changes are sufficient for `cargo test --all` to pass locally.