### PR TITLE
cubeb-api: Fix linker path after libcubeb submodule update.

### DIFF
--- a/cubeb-api/libcubeb-sys/build.rs
+++ b/cubeb-api/libcubeb-sys/build.rs
@@ -43,22 +43,22 @@ fn main() {
 
     if windows {
         println!("cargo:rustc-link-lib=static=cubeb");
-        println!("cargo:rustc-link-search=native={}", dst.display());
         println!("cargo:rustc-link-lib=dylib=avrt");
         println!("cargo:rustc-link-lib=dylib=ole32");
         println!("cargo:rustc-link-lib=dylib=user32");
         println!("cargo:rustc-link-lib=dylib=winmm");
+        println!("cargo:rustc-link-search=native={}/lib", dst.display());
     } else if darwin {
         println!("cargo:rustc-link-lib=static=cubeb");
         println!("cargo:rustc-link-lib=framework=AudioUnit");
         println!("cargo:rustc-link-lib=framework=CoreAudio");
         println!("cargo:rustc-link-lib=framework=CoreServices");
         println!("cargo:rustc-link-lib=dylib=c++");
-        println!("cargo:rustc-link-search=native={}", dst.display());
+        println!("cargo:rustc-link-search=native={}/lib", dst.display());
     } else {
         println!("cargo:rustc-link-lib=static=cubeb");
         println!("cargo:rustc-link-lib=dylib=stdc++");
-        println!("cargo:rustc-link-search=native={}", dst.display());
+        println!("cargo:rustc-link-search=native={}/lib", dst.display());
 
         pkg_config::find_library("alsa").unwrap();
         pkg_config::find_library("libpulse").unwrap();


### PR DESCRIPTION
https://github.com/kinetiknz/cubeb/commit/871456d0 causes the library to be generated in a lib subdirectory rather than in the root of the build output, so update build.rs to search in the new location.

If I had tested properly this change should've been included in PR #17, sorry!