### PR TITLE
Bump libcubeb and expose cubeb stream prefs

### DIFF
--- a/cubeb-api/Cargo.toml
+++ b/cubeb-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "cubeb"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 readme = "README.md"

--- a/cubeb-api/src/lib.rs
+++ b/cubeb-api/src/lib.rs
@@ -27,12 +27,13 @@ pub use context::Context;
 // Re-export cubeb_core types
 pub use cubeb_core::{ChannelLayout, Device, DeviceFormat, DeviceId, DeviceInfo,
                      DeviceState, DeviceType, Error, ErrorCode, LogLevel, Result,
-                     SampleFormat, State, StreamParams};
+                     SampleFormat, State, StreamParams, StreamPrefs};
 pub use cubeb_core::{DEVICE_FMT_F32BE, DEVICE_FMT_F32LE, DEVICE_FMT_S16BE,
                      DEVICE_FMT_S16LE};
 pub use cubeb_core::{DEVICE_PREF_ALL, DEVICE_PREF_MULTIMEDIA, DEVICE_PREF_NONE,
                      DEVICE_PREF_NOTIFICATION, DEVICE_PREF_VOICE};
 pub use cubeb_core::{DEVICE_TYPE_INPUT, DEVICE_TYPE_OUTPUT, DEVICE_TYPE_UNKNOWN};
+pub use cubeb_core::{STREAM_PREF_LOOPBACK, STREAM_PREF_NONE};
 
 use cubeb_core::binding::Binding;
 use cubeb_core::ffi;

--- a/cubeb-core/src/ffi.rs
+++ b/cubeb-core/src/ffi.rs
@@ -87,13 +87,21 @@ cubeb_enum! {
     }
 }
 
+cubeb_enum! {
+    pub enum cubeb_stream_prefs: c_int {
+        CUBEB_STREAM_PREF_NONE     = 0x00,
+        CUBEB_STREAM_PREF_LOOPBACK = 0x01,
+    }
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct cubeb_stream_params {
     pub format: cubeb_sample_format,
     pub rate: c_uint,
     pub channels: c_uint,
-    pub layout: cubeb_channel_layout
+    pub layout: cubeb_channel_layout,
+    pub prefs: cubeb_stream_prefs
 }
 
 #[repr(C)]
@@ -222,7 +230,7 @@ mod test {
         use super::cubeb_stream_params;
         assert_eq!(
             size_of::<cubeb_stream_params>(),
-            16usize,
+            20usize,
             concat!("Size of: ", stringify!(cubeb_stream_params))
         );
         assert_eq!(
@@ -268,6 +276,16 @@ mod test {
                 stringify!(cubeb_stream_params),
                 "::",
                 stringify!(layout)
+            )
+        );
+        assert_eq!(
+            unsafe { &(*(0 as *const cubeb_stream_params)).prefs as *const _ as usize },
+            16usize,
+            concat!(
+                "Alignment of field: ",
+                stringify!(cubeb_stream_params),
+                "::",
+                stringify!(prefs)
             )
         );
     }

--- a/cubeb-core/src/lib.rs
+++ b/cubeb-core/src/lib.rs
@@ -170,6 +170,14 @@ impl From<ffi::cubeb_channel_layout> for ChannelLayout {
     }
 }
 
+/// Miscellaneous stream preferences.
+bitflags! {
+    pub struct StreamPrefs: ffi::cubeb_stream_prefs {
+        const STREAM_PREF_NONE = ffi::CUBEB_STREAM_PREF_NONE;
+        const STREAM_PREF_LOOPBACK = ffi::CUBEB_STREAM_PREF_LOOPBACK;
+    }
+}
+
 /// Stream format initialization parameters.
 #[derive(Clone, Copy)]
 pub struct StreamParams {
@@ -232,6 +240,10 @@ impl StreamParams {
                CUBEB_LAYOUT_3F2_LFE => Layout3F2Lfe,
                CUBEB_LAYOUT_3F3R_LFE => Layout3F3RLfe,
                CUBEB_LAYOUT_3F4_LFE => Layout3F4Lfe)
+    }
+
+    pub fn prefs(&self) -> StreamPrefs {
+        StreamPrefs::from_bits(self.raw.prefs).unwrap()
     }
 }
 
@@ -594,4 +606,12 @@ mod tests {
         assert_eq!(params.rate(), 44100);
     }
 
+    #[test]
+    fn stream_params_raw_prefs() {
+        use STREAM_PREF_LOOPBACK;
+        let mut raw: super::ffi::cubeb_stream_params = unsafe { mem::zeroed() };
+        raw.prefs = STREAM_PREF_LOOPBACK.bits();
+        let params = unsafe { super::StreamParams::from_raw(&raw as *const _) };
+        assert_eq!(params.prefs(), STREAM_PREF_LOOPBACK);
+    }
 }


### PR DESCRIPTION
With https://github.com/kinetiknz/cubeb/pull/387 being merged, cubeb now exposes a stream preferences member on stream params. These prefs can be used to request loopback streams. This PR updates cubeb-rs to bump the underlying libcubeb and expose the new prefs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/20)
<!-- Reviewable:end -->
