### PR TITLE
Modify Context & Stream traits from &self to &mut self.

### DIFF
--- a/cubeb-backend/Cargo.toml
+++ b/cubeb-backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "cubeb-backend"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 keywords = ["cubeb"]

--- a/cubeb-backend/src/capi.rs
+++ b/cubeb-backend/src/capi.rs
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn capi_stream_init<CTX: Context>(
     state_callback: ffi::cubeb_state_callback,
     user_ptr: *mut c_void,
 ) -> c_int {
-    let ctx = &*(c as *const CTX);
+    let ctx = &mut *(c as *mut CTX);
     let anchor = &(); // for lifetime of stream_name as CStr
 
     let input_device = DeviceId::from_raw(input_device);
@@ -172,7 +172,7 @@ pub unsafe extern "C" fn capi_stream_destroy<STM>(s: *mut ffi::cubeb_stream) {
 pub unsafe extern "C" fn capi_stream_start<STM: Stream>(
     s: *mut ffi::cubeb_stream,
 ) -> c_int {
-    let stm = &*(s as *const STM);
+    let stm = &mut *(s as *mut STM);
 
     _try!(stm.start());
     ffi::CUBEB_OK
@@ -181,7 +181,7 @@ pub unsafe extern "C" fn capi_stream_start<STM: Stream>(
 pub unsafe extern "C" fn capi_stream_stop<STM: Stream>(
     s: *mut ffi::cubeb_stream,
 ) -> c_int {
-    let stm = &*(s as *const STM);
+    let stm = &mut *(s as *mut STM);
 
     _try!(stm.stop());
     ffi::CUBEB_OK
@@ -261,7 +261,7 @@ pub unsafe extern "C" fn capi_register_device_collection_changed<CTX: Context>(
     collection_changed_callback: ffi::cubeb_device_collection_changed_callback,
     user_ptr: *mut c_void,
 ) -> i32 {
-    let ctx = &*(c as *const CTX);
+    let ctx = &mut *(c as *mut CTX);
     let devtype = DeviceType::from_bits_truncate(devtype);
     _try!(ctx.register_device_collection_changed(
         devtype,

--- a/cubeb-backend/src/traits.rs
+++ b/cubeb-backend/src/traits.rs
@@ -25,7 +25,7 @@ pub trait Context {
     );
     #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
     fn stream_init(
-        &self,
+        &mut self,
         stream_name: Option<&CStr>,
         input_device: DeviceId,
         input_stream_params: Option<&ffi::cubeb_stream_params>,
@@ -37,7 +37,7 @@ pub trait Context {
         user_ptr: *mut c_void,
     ) -> Result<*mut ffi::cubeb_stream>;
     fn register_device_collection_changed(
-        &self,
+        &mut self,
         devtype: DeviceType,
         cb: ffi::cubeb_device_collection_changed_callback,
         user_ptr: *mut c_void,
@@ -45,13 +45,13 @@ pub trait Context {
 }
 
 pub trait Stream {
-    fn start(&self) -> Result<()>;
-    fn stop(&self) -> Result<()>;
-    fn reset_default_device(&self) -> Result<()>;
+    fn start(&mut self) -> Result<()>;
+    fn stop(&mut self) -> Result<()>;
+    fn reset_default_device(&mut self) -> Result<()>;
     fn position(&self) -> Result<u64>;
     fn latency(&self) -> Result<u32>;
-    fn set_volume(&self, volume: f32) -> Result<()>;
-    fn set_panning(&self, panning: f32) -> Result<()>;
+    fn set_volume(&mut self, volume: f32) -> Result<()>;
+    fn set_panning(&mut self, panning: f32) -> Result<()>;
     fn current_device(&self) -> Result<*const ffi::cubeb_device>;
     fn device_destroy(&self, device: *const ffi::cubeb_device) -> Result<()>;
     fn register_device_changed_callback(

--- a/cubeb-backend/tests/test_capi.rs
+++ b/cubeb-backend/tests/test_capi.rs
@@ -64,7 +64,7 @@ impl Context for TestContext {
         coll.count = 0;
     }
     fn stream_init(
-        &self,
+        &mut self,
         _stream_name: Option<&CStr>,
         _input_device: DeviceId,
         _input_stream_params: Option<&ffi::cubeb_stream_params>,
@@ -78,7 +78,7 @@ impl Context for TestContext {
         Ok(ptr::null_mut())
     }
     fn register_device_collection_changed(
-        &self,
+        &mut self,
         _dev_type: DeviceType,
         _collection_changed_callback: ffi::cubeb_device_collection_changed_callback,
         _user_ptr: *mut c_void,
@@ -90,13 +90,13 @@ impl Context for TestContext {
 struct TestStream {}
 
 impl Stream for TestStream {
-    fn start(&self) -> Result<()> {
+    fn start(&mut self) -> Result<()> {
         Ok(())
     }
-    fn stop(&self) -> Result<()> {
+    fn stop(&mut self) -> Result<()> {
         Ok(())
     }
-    fn reset_default_device(&self) -> Result<()> {
+    fn reset_default_device(&mut self) -> Result<()> {
         Ok(())
     }
     fn position(&self) -> Result<u64> {
@@ -105,11 +105,11 @@ impl Stream for TestStream {
     fn latency(&self) -> Result<u32> {
         Ok(0u32)
     }
-    fn set_volume(&self, volume: f32) -> Result<()> {
+    fn set_volume(&mut self, volume: f32) -> Result<()> {
         assert_eq!(volume, 0.5);
         Ok(())
     }
-    fn set_panning(&self, panning: f32) -> Result<()> {
+    fn set_panning(&mut self, panning: f32) -> Result<()> {
         assert_eq!(panning, 0.5);
         Ok(())
     }


### PR DESCRIPTION
This allows implementations to change internal state without resorting interior mutability shenanigans.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/22)
<!-- Reviewable:end -->
