### PR TITLE
Support building in tree for Gecko.

### DIFF
--- a/cubeb-api/Cargo.toml
+++ b/cubeb-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 readme = "README.md"
@@ -19,4 +19,4 @@ circle-ci = { repository = "djg/cubeb-rs" }
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
 
 [dependencies]
-cubeb-core = { path = "../cubeb-core", version = "0.4" }
+cubeb-core = { path = "../cubeb-core", version = "0.4.1" }

--- a/cubeb-api/Cargo.toml
+++ b/cubeb-api/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "cubeb"
 version = "0.4.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
@@ -15,6 +14,9 @@ categories = ["api-bindings"]
 
 [badges]
 circle-ci = { repository = "djg/cubeb-rs" }
+
+[features]
+gecko-in-tree = ["cubeb-core/gecko-in-tree"]
 
 [dependencies]
 cubeb-core = { path = "../cubeb-core", version = "0.4" }

--- a/cubeb-backend/Cargo.toml
+++ b/cubeb-backend/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
-
 name = "cubeb-backend"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 keywords = ["cubeb"]
@@ -19,4 +18,4 @@ circle-ci = { repository = "djg/cubeb-rs" }
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
 
 [dependencies]
-cubeb-core = { path = "../cubeb-core", version = "0.4" }
+cubeb-core = { path = "../cubeb-core", version = "0.4.1" }

--- a/cubeb-backend/Cargo.toml
+++ b/cubeb-backend/Cargo.toml
@@ -15,5 +15,8 @@ categories = ["api-bindings"]
 [badges]
 circle-ci = { repository = "djg/cubeb-rs" }
 
+[features]
+gecko-in-tree = ["cubeb-core/gecko-in-tree"]
+
 [dependencies]
 cubeb-core = { path = "../cubeb-core", version = "0.4" }

--- a/cubeb-core/Cargo.toml
+++ b/cubeb-core/Cargo.toml
@@ -14,6 +14,9 @@ categories = ["api-bindings"]
 [badges]
 circle-ci = { repository = "djg/cubeb-rs" }
 
+[features]
+gecko-in-tree = ["cubeb-sys/gecko-in-tree"]
+
 [dependencies]
 bitflags = "1.0"
 cubeb-sys = { path = "../cubeb-sys", version = "0.4" }

--- a/cubeb-core/Cargo.toml
+++ b/cubeb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-core"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 keywords = ["cubeb"]
@@ -19,4 +19,4 @@ gecko-in-tree = ["cubeb-sys/gecko-in-tree"]
 
 [dependencies]
 bitflags = "1.0"
-cubeb-sys = { path = "../cubeb-sys", version = "0.4" }
+cubeb-sys = { path = "../cubeb-sys", version = "0.4.1" }

--- a/cubeb-sys/Cargo.toml
+++ b/cubeb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-sys"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 repository = "https://github.com/djg/cubeb-rs"
 license = "ISC"

--- a/cubeb-sys/Cargo.toml
+++ b/cubeb-sys/Cargo.toml
@@ -12,6 +12,9 @@ build = "build.rs"
 [badges]
 circle-ci = { repository = "djg/cubeb-rs" }
 
+[features]
+gecko-in-tree = []
+
 [build-dependencies]
 pkg-config = "0.3"
 cmake = "0.1.2"

--- a/cubeb-sys/build.rs
+++ b/cubeb-sys/build.rs
@@ -20,6 +20,11 @@ macro_rules! t {
 }
 
 fn main() {
+    let gecko_in_tree = env::var("CARGO_FEATURE_GECKO_IN_TREE").is_ok();
+    if gecko_in_tree {
+        return;
+    }
+
     if env::var("LIBCUBEB_SYS_USE_PKG_CONFIG").is_ok() {
         if pkg_config::find_library("libcubeb").is_ok() {
             return;

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Dan Glastonbury <dan.glastonbury@gmail.com>"]
 build = "build.rs"
 
+[features]
+gecko-in-tree = ["cubeb-sys/gecko-in-tree"]
+
 [dependencies]
 cubeb-sys = { path = "../cubeb-sys" }
 


### PR DESCRIPTION
Add a feature `gecko-in-tree` that disables the automatic addition of linking against cubeb.a + system libraries when using these crates. (Gecko links directly against cubeb as object files).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/25)
<!-- Reviewable:end -->
