### PR TITLE
cubeb-core: Fix device_collection memory leaks.

### DIFF
--- a/cubeb-core/Cargo.toml
+++ b/cubeb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-core"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 keywords = ["cubeb"]

--- a/cubeb-core/src/context.rs
+++ b/cubeb-core/src/context.rs
@@ -123,25 +123,15 @@ impl ContextRef {
     }
 
     pub fn enumerate_devices(&self, devtype: DeviceType) -> Result<DeviceCollection> {
-        let coll = DeviceCollection::default();
+        let mut coll = ffi::cubeb_device_collection::default();
         unsafe {
             let _ = try_call!(ffi::cubeb_enumerate_devices(
                 self.as_ptr(),
                 devtype.bits(),
-                coll.as_ptr()
+                &mut coll
             ));
         }
-        Ok(coll)
-    }
-
-    pub fn device_collection_destroy(&self, collection: DeviceCollection) -> Result<()> {
-        unsafe {
-            let _ = try_call!(ffi::cubeb_device_collection_destroy(
-                self.as_ptr(),
-                collection.as_ptr()
-            ));
-        }
-        Ok(())
+        Ok(DeviceCollection::init_with_ctx(self, coll))
     }
 
     pub unsafe fn register_device_collection_changed(

--- a/cubeb-core/src/device_collection.rs
+++ b/cubeb-core/src/device_collection.rs
@@ -3,16 +3,81 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-use DeviceInfo;
+use {ContextRef, DeviceInfo};
 use ffi;
+use ffi_types;
 use std::{ops, slice};
 
 /// A collection of `DeviceInfo` used by libcubeb
-ffi_type_stack! {
-    type CType = ffi::cubeb_device_collection;
-    #[derive(Debug)]
-    pub struct DeviceCollection;
-    pub struct DeviceCollectionRef;
+type CType = ffi::cubeb_device_collection;
+
+#[derive(Debug)]
+pub struct DeviceCollection<'ctx>(CType, &'ctx ContextRef);
+
+impl<'ctx> DeviceCollection<'ctx> {
+    pub(crate) fn init_with_ctx(ctx: &ContextRef, coll: CType) -> DeviceCollection {
+        DeviceCollection(coll, ctx)
+    }
+
+    pub fn as_ptr(&self) -> *mut CType {
+        &self.0 as *const CType as *mut CType
+    }
+}
+
+impl<'ctx> Drop for DeviceCollection<'ctx> {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = try_call!(ffi::cubeb_device_collection_destroy(
+                self.1.as_ptr(),
+                &mut self.0
+            ));
+        }
+    }
+}
+
+impl<'ctx> ::std::ops::Deref for DeviceCollection<'ctx> {
+    type Target = DeviceCollectionRef;
+
+    #[inline]
+    fn deref(&self) -> &DeviceCollectionRef {
+        let ptr = &self.0 as *const CType as *mut CType;
+        unsafe { DeviceCollectionRef::from_ptr(ptr) }
+    }
+}
+
+impl<'ctx> ::std::convert::AsRef<DeviceCollectionRef> for DeviceCollection<'ctx> {
+    #[inline]
+    fn as_ref(&self) -> &DeviceCollectionRef {
+        &**self
+    }
+}
+
+pub struct DeviceCollectionRef(ffi_types::Opaque);
+
+impl DeviceCollectionRef {
+    #[inline]
+    pub unsafe fn from_ptr<'a>(ptr: *mut CType) -> &'a Self {
+        &*(ptr as *mut _)
+    }
+
+    #[inline]
+    pub unsafe fn from_ptr_mut<'a>(ptr: *mut CType) -> &'a mut Self {
+        &mut *(ptr as *mut _)
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *mut CType {
+        self as *const _ as *mut _
+    }
+}
+
+impl ::std::fmt::Debug for DeviceCollectionRef {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        let ptr = self as *const DeviceCollectionRef as usize;
+        f.debug_tuple(stringify!(DeviceCollectionRef))
+            .field(&ptr)
+            .finish()
+    }
 }
 
 impl ops::Deref for DeviceCollectionRef {


### PR DESCRIPTION
Make DeviceCollection own the memory it's given and clean up on drop.
Manually calling device_collection_destroy on Context is too dangerous.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/26)
<!-- Reviewable:end -->
