### PR TITLE
cubeb-core: Handle cubeb_init failure.

### DIFF
--- a/cubeb-core/src/context.rs
+++ b/cubeb-core/src/context.rs
@@ -27,7 +27,7 @@ impl Context {
         let context_name = as_ptr!(context_name);
         let backend_name = as_ptr!(backend_name);
         unsafe {
-            ffi::cubeb_init(&mut context, context_name, backend_name);
+            try_call!(ffi::cubeb_init(&mut context, context_name, backend_name));
             Ok(Context::from_ptr(context))
         }
     }


### PR DESCRIPTION
`ffi::cubeb_init` missing `try_call!` macro.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/28)
<!-- Reviewable:end -->
