### PR TITLE
Adjust drop order in cubeb_api::Stream and stop stream on Drop in cubeb_core::Stream

### DIFF
--- a/cubeb-core/src/stream.rs
+++ b/cubeb-core/src/stream.rs
@@ -93,9 +93,14 @@ impl StreamParamsRef {
     }
 }
 
+unsafe fn wrapped_cubeb_stream_destroy(stream: *mut ffi::cubeb_stream) {
+    ffi::cubeb_stream_stop(stream);
+    ffi::cubeb_stream_destroy(stream);
+}
+
 ffi_type_heap! {
     type CType = ffi::cubeb_stream;
-    fn drop = ffi::cubeb_stream_destroy;
+    fn drop = wrapped_cubeb_stream_destroy;
     pub struct Stream;
     pub struct StreamRef;
 }


### PR DESCRIPTION
1. cubeb_api::Stream was dropping StreamCallbacks explicitly, then relying on Rust's implicit Drop ordering to drop the interior cubeb_core::Stream.  The cubeb_core::Stream could potentially use the StreamCallbacks before/during destruction, so we need to free these after the cubeb_core::Stream.
2. If a cubeb_core::Stream has been started and is then dropped, it's possible for a UAF to occur where the stream is destroyed but the callback is still in flight.  A stream must be stopped before destruction, so this takes the simple approach of blindly stopping any stream before calling cubeb_stream_destroy.  The major libcubeb backends all allow this, but it's not explicitly permitted by the API.  Rather than forcing the caller to track an additional "running" state for the stream, it seemed cleaner to change the libcubeb API to permit this.  I'll file a libcubeb bug to update the documentation.

This is intended to fix [BMO 1447097](https://bugzilla.mozilla.org/show_bug.cgi?id=1447097).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/31)
<!-- Reviewable:end -->
