### PR TITLE
Remove the gcc dependency and bump version

### DIFF
--- a/cubeb-sys/Cargo.toml
+++ b/cubeb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-sys"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 repository = "https://github.com/djg/cubeb-rs"
 license = "ISC"
@@ -18,4 +18,3 @@ gecko-in-tree = []
 [build-dependencies]
 pkg-config = "0.3"
 cmake = "0.1.2"
-gcc = "0.3"

--- a/cubeb-sys/build.rs
+++ b/cubeb-sys/build.rs
@@ -4,7 +4,6 @@
 // accompanying file LICENSE for details.
 
 extern crate cmake;
-extern crate gcc;
 extern crate pkg_config;
 
 use std::env;


### PR DESCRIPTION
It isn't used...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/32)
<!-- Reviewable:end -->
