### PR TITLE
Reduce multiple stops

### DIFF
--- a/cubeb-api/Cargo.toml
+++ b/cubeb-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 readme = "README.md"

--- a/cubeb-api/src/stream.rs
+++ b/cubeb-api/src/stream.rs
@@ -58,15 +58,15 @@
 //! }
 //! ```
 
-use {ContextRef, DeviceId, Error, Result, State, StreamParamsRef};
 use cubeb_core;
 use ffi;
-use std::{ops, panic, ptr};
 use std::ffi::CString;
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::os::raw::{c_long, c_void};
 use std::slice::{from_raw_parts, from_raw_parts_mut};
+use std::{ops, panic, ptr};
+use {ContextRef, DeviceId, Error, Result, State, StreamParamsRef};
 
 pub type DataCallback<F> = FnMut(&[F], &mut [F]) -> isize + Send + Sync + 'static;
 pub type StateCallback = FnMut(State) + Send + Sync + 'static;
@@ -78,8 +78,7 @@ pub struct StreamCallbacks<F> {
     pub(crate) device_changed: Option<Box<DeviceChangedCallback>>,
 }
 
-pub struct Stream<F>(ManuallyDrop<cubeb_core::Stream>,
-                     PhantomData<*const F>);
+pub struct Stream<F>(ManuallyDrop<cubeb_core::Stream>, PhantomData<*const F>);
 
 impl<F> Stream<F> {
     fn new(s: cubeb_core::Stream) -> Stream<F> {

--- a/cubeb-core/Cargo.toml
+++ b/cubeb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-core"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 keywords = ["cubeb"]

--- a/cubeb-core/src/stream.rs
+++ b/cubeb-core/src/stream.rs
@@ -3,10 +3,10 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-use {ChannelLayout, DeviceRef, Result, SampleFormat};
 use ffi;
 use std::os::raw::c_void;
 use std::ptr;
+use {ChannelLayout, DeviceRef, Result, SampleFormat};
 
 /// Stream states signaled via `state_callback`.
 #[derive(PartialEq, Eq, Clone, Debug, Copy)]
@@ -199,8 +199,8 @@ impl StreamRef {
 
 #[cfg(test)]
 mod tests {
-    use {StreamParams, StreamParamsRef, StreamPrefs};
     use std::mem;
+    use {StreamParams, StreamParamsRef, StreamPrefs};
 
     #[test]
     fn stream_params_default() {

--- a/cubeb-core/src/stream.rs
+++ b/cubeb-core/src/stream.rs
@@ -93,14 +93,9 @@ impl StreamParamsRef {
     }
 }
 
-unsafe fn wrapped_cubeb_stream_destroy(stream: *mut ffi::cubeb_stream) {
-    ffi::cubeb_stream_stop(stream);
-    ffi::cubeb_stream_destroy(stream);
-}
-
 ffi_type_heap! {
     type CType = ffi::cubeb_stream;
-    fn drop = wrapped_cubeb_stream_destroy;
+    fn drop = ffi::cubeb_stream_destroy;
     pub struct Stream;
     pub struct StreamRef;
 }


### PR DESCRIPTION
When debugging audioipc `ipctest` example I noticed:
```
stream Started
stream Stopped
stream Stopped
stream Stopped
```

Moving the stop into `Stream<F>::drop` removes one of the stream stops (in conjunction with changing audioipc server to use the low-level `cubeb_core::Stream`)

@kinetiknz can you verify my assumptions in the comments of `Stream<F>::drop` (ie. verify that removing `ManuallyDrop` is OK, although I'm not to precious about removing it or leaving it in. The `debug_assert_eq!` is intended as a poor test if we mess up stream layout again)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/33)
<!-- Reviewable:end -->
