### PR TITLE
Fix cubeb_channel enum on Windows.

### DIFF
--- a/cubeb-sys/src/channel.rs
+++ b/cubeb-sys/src/channel.rs
@@ -3,10 +3,13 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-use std::os::raw::c_uint;
+#[cfg(windows)]
+use std::os::raw::c_int as c_enum;
+#[cfg(not(windows))]
+use std::os::raw::c_uint as c_enum;
 
 cubeb_enum! {
-    pub enum cubeb_channel : c_uint {
+    pub enum cubeb_channel : c_enum {
         CHANNEL_UNKNOWN = 0,
         CHANNEL_FRONT_LEFT = 1 << 0,
         CHANNEL_FRONT_RIGHT = 1 << 1,


### PR DESCRIPTION
Tiny build fix for cubeb-rs caused by the underlying default C enum type being `int` on Windows and `unsigned int` on other platforms.

r? @ChunMinChang please

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/34)
<!-- Reviewable:end -->
