### PR TITLE
Implement stream_register_device_changed_callback

### DIFF
--- a/cubeb-backend/src/capi.rs
+++ b/cubeb-backend/src/capi.rs
@@ -53,7 +53,8 @@ macro_rules! capi_new(
             stream_set_panning: Some($crate::capi::capi_stream_set_panning::<$stm>),
             stream_get_current_device: Some($crate::capi::capi_stream_get_current_device::<$stm>),
             stream_device_destroy: Some($crate::capi::capi_stream_device_destroy::<$stm>),
-            stream_register_device_changed_callback: None,
+            stream_register_device_changed_callback:
+                Some($crate::capi::capi_stream_register_device_changed_callback::<$stm>),
             register_device_collection_changed:
                 Some($crate::capi::capi_register_device_collection_changed::<$ctx>)
         }));
@@ -253,6 +254,16 @@ pub unsafe extern "C" fn capi_stream_device_destroy<STM: StreamOps>(
     let stm = &mut *(s as *mut STM);
     let device = DeviceRef::from_ptr(device);
     let _ = stm.device_destroy(device);
+    ffi::CUBEB_OK
+}
+
+pub unsafe extern "C" fn capi_stream_register_device_changed_callback<STM: StreamOps>(
+    s: *mut ffi::cubeb_stream,
+    device_changed_callback: ffi::cubeb_device_changed_callback,
+) -> c_int {
+    let stm = &mut *(s as *mut STM);
+
+    _try!(stm.register_device_changed_callback(device_changed_callback));
     ffi::CUBEB_OK
 }
 


### PR DESCRIPTION
To test if `register_device_changed_callback` for a `StreamOps` implementation is callable from C code, `register_device_changed_callback` should be exposed via `stream_register_device_changed_callback`. 

 Could you take a look? @kinetiknz 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/36)
<!-- Reviewable:end -->
