### PR TITLE
Return the result from device_collection_destroy directly

### DIFF
--- a/cubeb-backend/src/capi.rs
+++ b/cubeb-backend/src/capi.rs
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn capi_device_collection_destroy<CTX: ContextOps>(
 ) -> c_int {
     let ctx = &mut *(c as *mut CTX);
     let collection = DeviceCollectionRef::from_ptr_mut(collection);
-    let _ = ctx.device_collection_destroy(collection);
+    _try!(ctx.device_collection_destroy(collection));
     ffi::CUBEB_OK
 }
 


### PR DESCRIPTION
`capi_device_collection_destroy` always returns `CUBEB_OK`. However, `cubeb_device_collection_destroy` is supposed to [return the result from its implementation directly](https://github.com/kinetiknz/cubeb/blob/d5254913ed005996d5d11a9e7fe61bc4def8d5e4/src/cubeb.c#L605-L611). The behavior of `capi_device_collection_destroy` should be aligned with `cubeb_device_collection_destroy`.

@kinetiknz, could you review this change ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/37)
<!-- Reviewable:end -->
