### PR TITLE
Update Circle CI to use rust 1.33

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: mozmedia/cubeb-rust:fc27
+      - image: mozmedia/cubeb-rust:latest
     environment:
       TZ: "/usr/share/zoneinfo/Australia/Brisbane"
     steps:


### PR DESCRIPTION
Use `latest` tag of `mozmedia/cubeb-rust` instead of `fc27`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/40)
<!-- Reviewable:end -->
