### PR TITLE
Drop 'static lifetime from ContextOps::backend_id return value.

### DIFF
--- a/cubeb-backend/src/traits.rs
+++ b/cubeb-backend/src/traits.rs
@@ -11,7 +11,7 @@ use std::os::raw::c_void;
 
 pub trait ContextOps {
     fn init(context_name: Option<&CStr>) -> Result<Context>;
-    fn backend_id(&mut self) -> &'static CStr;
+    fn backend_id(&mut self) -> &CStr;
     fn max_channel_count(&mut self) -> Result<u32>;
     fn min_latency(&mut self, params: StreamParams) -> Result<u32>;
     fn preferred_sample_rate(&mut self) -> Result<u32>;


### PR DESCRIPTION
This allows implementations to return a value with a shorter lifetime, e.g. tied to the associated implementation of ContextOp.

r? @ChunMinChang please

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/42)
<!-- Reviewable:end -->
