### PR TITLE
Only print filename in the log

### DIFF
--- a/cubeb-backend/src/log.rs
+++ b/cubeb-backend/src/log.rs
@@ -23,7 +23,8 @@ macro_rules! cubeb_log_internal {
     };
     (__INTERNAL__ $msg: expr) => {
         if let Some(log_callback) = $crate::ffi::g_cubeb_log_callback {
-            let cstr = ::std::ffi::CString::new(format!("{}:{}: {}\n", file!(), line!(), $msg)).unwrap();
+            let filename = std::path::Path::new(file!()).file_name().unwrap().to_str().unwrap();
+            let cstr = ::std::ffi::CString::new(format!("{}:{}: {}\n", filename, line!(), $msg)).unwrap();
             log_callback(cstr.as_ptr());
         }
     }


### PR DESCRIPTION
Instead of printing the full path to the file that is currently running,
we should print the filename only. As long as we have the filename and
the line, we know where the log comes from.

This is a fix for [BMO 1628132](https://bugzilla.mozilla.org/show_bug.cgi?id=1628132). r? @kinetiknz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/50)
<!-- Reviewable:end -->
