### PR TITLE
Do not allocate buffer when logging messages

### DIFF
--- a/cubeb-backend/src/log.rs
+++ b/cubeb-backend/src/log.rs
@@ -33,10 +33,11 @@ macro_rules! cubeb_log_internal {
                 .unwrap();
             // 2 for ':', 1 for ' ', 1 for '\n', and 1 for converting `line!()` to number of digits
             let len = filename.len() + ((line!() as f32).log10() as usize) + $msg.len() + 5;
-            assert!(len < buf.len(), "log is too long!");
-            write!(&mut buf[..], "{}:{}: {}\n", filename, line!(), $msg).unwrap();
-            buf[len] = 0;
-            let cstr = unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(&buf[..len + 1]) };
+            debug_assert!(len < buf.len(), "log will be truncated");
+            let _ = write!(&mut buf[..], "{}:{}: {}\n", filename, line!(), $msg);
+            let last = std::cmp::min(len, buf.len() - 1);
+            buf[last] = 0;
+            let cstr = unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(&buf[..last + 1]) };
             log_callback(cstr.as_ptr());
         }
     }

--- a/cubeb-backend/src/log.rs
+++ b/cubeb-backend/src/log.rs
@@ -31,10 +31,10 @@ macro_rules! cubeb_log_internal {
                 .unwrap()
                 .to_str()
                 .unwrap();
-            // +2 for ':', +1 for ' ', and +1 for converting line value to number of digits
-            let len = filename.len() + ((line!() as f32).log10() as usize) + $msg.len() + 4;
+            // 2 for ':', 1 for ' ', 1 for '\n', and 1 for converting `line!()` to number of digits
+            let len = filename.len() + ((line!() as f32).log10() as usize) + $msg.len() + 5;
             assert!(len < buf.len(), "log is too long!");
-            write!(&mut buf[..], "{}:{}: {}", filename, line!(), $msg).unwrap();
+            write!(&mut buf[..], "{}:{}: {}\n", filename, line!(), $msg).unwrap();
             buf[len] = 0;
             let cstr = unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(&buf[..len + 1]) };
             log_callback(cstr.as_ptr());

--- a/cubeb-backend/src/log.rs
+++ b/cubeb-backend/src/log.rs
@@ -32,7 +32,7 @@ macro_rules! cubeb_log_internal {
                 .to_str()
                 .unwrap();
             // 2 for ':', 1 for ' ', 1 for '\n', and 1 for converting `line!()` to number of digits
-            let len = filename.len() + ((line!() as f32).log10() as usize) + $msg.len() + 5;
+            let len = filename.len() + ((line!() as f32).log10().trunc() as usize) + $msg.len() + 5;
             debug_assert!(len < buf.len(), "log will be truncated");
             let _ = write!(&mut buf[..], "{}:{}: {}\n", filename, line!(), $msg);
             let last = std::cmp::min(len, buf.len() - 1);


### PR DESCRIPTION
Address the performance issue mentioned here: https://github.com/djg/cubeb-rs/pull/50#pullrequestreview-389875184. When logging message, we should avoid allocating a string, which may consume considerable time. That is not ideal for the real-time threads.

r? @kinetiknz @padenot

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/51)
<!-- Reviewable:end -->
