### PR TITLE
Add support for cubeb_stream_set_name

### DIFF
--- a/cubeb-api/Cargo.toml
+++ b/cubeb-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 readme = "README.md"
@@ -19,4 +19,4 @@ circle-ci = { repository = "djg/cubeb-rs" }
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
 
 [dependencies]
-cubeb-core = { path = "../cubeb-core", version = "0.7.0" }
+cubeb-core = { path = "../cubeb-core", version = "0.8.0" }

--- a/cubeb-backend/Cargo.toml
+++ b/cubeb-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-backend"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 keywords = ["cubeb"]
@@ -18,4 +18,4 @@ circle-ci = { repository = "djg/cubeb-rs" }
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
 
 [dependencies]
-cubeb-core = { path = "../cubeb-core", version = "0.7.0" }
+cubeb-core = { path = "../cubeb-core", version = "0.8.0" }

--- a/cubeb-backend/src/capi.rs
+++ b/cubeb-backend/src/capi.rs
@@ -51,6 +51,7 @@ macro_rules! capi_new(
             stream_get_latency: Some($crate::capi::capi_stream_get_latency::<$stm>),
             stream_get_input_latency: Some($crate::capi::capi_stream_get_input_latency::<$stm>),
             stream_set_volume: Some($crate::capi::capi_stream_set_volume::<$stm>),
+            stream_set_name: Some($crate::capi::capi_stream_set_name::<$stm>),
             stream_get_current_device: Some($crate::capi::capi_stream_get_current_device::<$stm>),
             stream_device_destroy: Some($crate::capi::capi_stream_device_destroy::<$stm>),
             stream_register_device_changed_callback:
@@ -235,6 +236,20 @@ pub unsafe extern "C" fn capi_stream_set_volume<STM: StreamOps>(
 
     _try!(stm.set_volume(volume));
     ffi::CUBEB_OK
+}
+
+pub unsafe extern "C" fn capi_stream_set_name<STM: StreamOps>(
+    s: *mut ffi::cubeb_stream,
+    name: *const c_char,
+) -> c_int {
+    let stm = &mut *(s as *mut STM);
+    let anchor = &();
+    if let Some(name) = opt_cstr(anchor, name) {
+        _try!(stm.set_name(name));
+        ffi::CUBEB_OK
+    } else {
+        ffi::CUBEB_ERROR_INVALID_PARAMETER
+    }
 }
 
 pub unsafe extern "C" fn capi_stream_get_current_device<STM: StreamOps>(

--- a/cubeb-backend/src/ops.rs
+++ b/cubeb-backend/src/ops.rs
@@ -67,6 +67,8 @@ pub struct Ops {
         Option<unsafe extern "C" fn(stream: *mut ffi::cubeb_stream, latency: *mut u32) -> c_int>,
     pub stream_set_volume:
         Option<unsafe extern "C" fn(stream: *mut ffi::cubeb_stream, volumes: c_float) -> c_int>,
+    pub stream_set_name:
+        Option<unsafe extern "C" fn(stream: *mut ffi::cubeb_stream, name: *const c_char) -> c_int>,
     pub stream_get_current_device: Option<
         unsafe extern "C" fn(stream: *mut ffi::cubeb_stream, device: *mut *mut ffi::cubeb_device)
             -> c_int,

--- a/cubeb-backend/src/traits.rs
+++ b/cubeb-backend/src/traits.rs
@@ -50,6 +50,7 @@ pub trait StreamOps {
     fn latency(&mut self) -> Result<u32>;
     fn input_latency(&mut self) -> Result<u32>;
     fn set_volume(&mut self, volume: f32) -> Result<()>;
+    fn set_name(&mut self, name: &CStr) -> Result<()>;
     fn current_device(&mut self) -> Result<&DeviceRef>;
     fn device_destroy(&mut self, device: &DeviceRef) -> Result<()>;
     fn register_device_changed_callback(

--- a/cubeb-backend/tests/test_capi.rs
+++ b/cubeb-backend/tests/test_capi.rs
@@ -107,6 +107,10 @@ impl StreamOps for TestStream {
         assert_eq!(volume, 0.5);
         Ok(())
     }
+    fn set_name(&mut self, name: &CStr) -> Result<()> {
+        assert_eq!(name, CStr::from_bytes_with_nul(b"test\0").unwrap());
+        Ok(())
+    }
     fn current_device(&mut self) -> Result<&DeviceRef> {
         Ok(unsafe { DeviceRef::from_ptr(0xDEAD_BEEF as *mut _) })
     }
@@ -218,6 +222,14 @@ fn test_ops_stream_set_volume() {
     let s: *mut ffi::cubeb_stream = ptr::null_mut();
     unsafe {
         OPS.stream_set_volume.unwrap()(s, 0.5);
+    }
+}
+
+#[test]
+fn test_ops_stream_set_name() {
+    let s: *mut ffi::cubeb_stream = ptr::null_mut();
+    unsafe {
+        OPS.stream_set_name.unwrap()(s, CStr::from_bytes_with_nul(b"test\0").unwrap().as_ptr());
     }
 }
 

--- a/cubeb-core/Cargo.toml
+++ b/cubeb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-core"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 keywords = ["cubeb"]
@@ -19,4 +19,4 @@ gecko-in-tree = ["cubeb-sys/gecko-in-tree"]
 
 [dependencies]
 bitflags = "1.2.0"
-cubeb-sys = { path = "../cubeb-sys", version = "0.7.0" }
+cubeb-sys = { path = "../cubeb-sys", version = "0.8.0" }

--- a/cubeb-core/src/stream.rs
+++ b/cubeb-core/src/stream.rs
@@ -7,6 +7,7 @@ use {ChannelLayout, DeviceRef, Result, SampleFormat};
 use ffi;
 use std::os::raw::c_void;
 use std::ptr;
+use std::ffi::CStr;
 
 /// Stream states signaled via `state_callback`.
 #[derive(PartialEq, Eq, Clone, Debug, Copy)]
@@ -157,6 +158,11 @@ impl StreamRef {
     /// Set the volume for a stream.
     pub fn set_volume(&self, volume: f32) -> Result<()> {
         unsafe { call!(ffi::cubeb_stream_set_volume(self.as_ptr(), volume)) }
+    }
+
+    /// Change a stream's name
+    pub fn set_name(&self, name: &CStr) -> Result<()> {
+        unsafe { call!(ffi::cubeb_stream_set_name(self.as_ptr(), name.as_ptr())) }
     }
 
     /// Get the current output device for this stream.

--- a/cubeb-sys/Cargo.toml
+++ b/cubeb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-sys"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 repository = "https://github.com/djg/cubeb-rs"
 license = "ISC"

--- a/cubeb-sys/src/stream.rs
+++ b/cubeb-sys/src/stream.rs
@@ -8,7 +8,7 @@ use channel::cubeb_channel_layout;
 use device::cubeb_device;
 use format::cubeb_sample_format;
 use std::{fmt, mem};
-use std::os::raw::{c_float, c_int, c_uint, c_void};
+use std::os::raw::{c_float, c_int, c_uint, c_void, c_char};
 
 cubeb_enum! {
     pub enum cubeb_stream_prefs {
@@ -68,6 +68,7 @@ extern "C" {
     pub fn cubeb_stream_get_latency(stream: *mut cubeb_stream, latency: *mut c_uint) -> c_int;
     pub fn cubeb_stream_get_input_latency(stream: *mut cubeb_stream, latency: *mut c_uint) -> c_int;
     pub fn cubeb_stream_set_volume(stream: *mut cubeb_stream, volume: c_float) -> c_int;
+    pub fn cubeb_stream_set_name(stream: *mut cubeb_stream, name: *const c_char) -> c_int;
     pub fn cubeb_stream_get_current_device(
         stream: *mut cubeb_stream,
         device: *mut *mut cubeb_device,


### PR DESCRIPTION
Blocked by https://github.com/kinetiknz/cubeb/pull/615. This won't work until the submodule is updated.

This PR adds support for the cubeb_stream_set_name method. I am not sure if the types are entirely correct when dealing with CStr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/cubeb-rs/54)
<!-- Reviewable:end -->
